### PR TITLE
Updates related to Grell Friedas convection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 This file documents all notable changes to the GEOS-Chem repository starting in version 14.0.0, including all GEOS-Chem Classic and GCHP run directory updates.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased] - TBD
+### Added
+- Specified meteorology source in GCHP geoschem_config.yml
+- Added Input_Opt logical for whether to reconstruct convective precipitation fluxes rather than use met-fields
+- Added to run directory creation a warning about convection discontinuity and bug if GEOS-FP meteorology is chosen
+- Added surface precipitation flux fields as inputs to GCHP
+
+### Fixed
+- Fixed zero convective precipitation and high cloud base in runs using GEOS-FP (>=01Jun2020) or GEOS-IT
+- Fixed PDOWN definition to lower rather than upper edge
+
+### Changed
+
+### Removed
+-Removed re-evaporation requirement for washout
 
 ## [14.4.3] - 2024-08-13
 ### Added

--- a/GeosCore/convection_mod.F90
+++ b/GeosCore/convection_mod.F90
@@ -502,7 +502,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    LOGICAL                :: AER,         IS_Hg,     Is_GF_Conv
+    LOGICAL                :: AER,         IS_Hg
     INTEGER                :: IC,          ISTEP,     K
     INTEGER                :: KTOP,        NC,        NDT
     INTEGER                :: NLAY,        NS,        CLDBASE
@@ -592,8 +592,6 @@ CONTAINS
 
     ! Is this a Hg simulation?
     IS_Hg = Input_Opt%ITS_A_MERCURY_SIM
-    ! GF convection scheme?
-    Is_GF_Conv = Input_Opt%Met_Conv_Is_Grell_Freitas
 
     IF ( State_Grid%NZ > 72 .or. &
          Input_Opt%MetField == "MODELE2.1" ) THEN 
@@ -608,7 +606,7 @@ CONTAINS
     DNS      = DBLE( NS )               ! Num internal timesteps (real)
     SDT      = DBLE( NDT ) / DBLE( NS ) ! seconds in internal timestep
 
-    IF ( Is_GF_Conv == .FALSE. ) THEN
+    IF ( .NOT. Input_Opt%Reconstruct_Conv_Precip_Flux ) THEN
        ! RAS scheme
        REEVAPCN(:) = REEVAPCN_MET(:)
        DQRCU(:) = DQRCU_MET(:)
@@ -658,7 +656,7 @@ CONTAINS
     ! PFLCU and PFICU are converted from kg/m2/s to m3/m2/s
     ! using water and ice densities, respectively.
     ! m3/m2/s becomes cm3/cm2/s using a factor of 100.
-    IF ( Is_GF_Conv == .FALSE. ) THEN
+    IF ( .NOT. Input_Opt%Reconstruct_Conv_Precip_Flux ) THEN
        PDOWN(:) = ( ( PFLCU(:) / 1000e+0_fp ) &
                 +   ( PFICU(:) /  917e+0_fp ) ) * 100e+0_fp
     ELSE

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3192,7 +3192,7 @@ CONTAINS
        WRITE( 6, 100 ) 'Reconstruct convective precipitation flux?   : ', &
             Input_Opt%Reconstruct_Conv_Precip_Flux
 
-       IF ( Input_Opt%MetFields == 'GEOSFP' ) THEN
+       IF ( Input_Opt%MetField == 'GEOSFP' ) THEN
           IF ( Input_Opt%Reconstruct_Conv_Precip_Flux ) THEN
              WRITE( 6, 90 ) 'WARNING: Convection will assume met data is on or after 01Jun2020!'
           ELSE

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3059,7 +3059,9 @@ CONTAINS
 ! !IROUTINE: config_convection_mixing
 !
 ! !DESCRIPTION: Copies convection & PBL mixing information from the Config
-!  object to Input_Opt, and does necessary checks.
+!  object to Input_Opt, and does necessary checks. Also sets whether
+!  to reconstruct convective precipitation flux based on meteorology
+!  source and simulation start date.
 !\\
 !\\
 ! !INTERFACE:
@@ -3143,12 +3145,39 @@ CONTAINS
     ENDIF
     Input_Opt%LNLPBL = v_bool
 
+    !------------------------------------------------------------------------
+    ! Other settings based on inputs
+    !------------------------------------------------------------------------
+
     ! Set the PBL drydep flag. This determines if dry deposition is
     ! applied (and drydep frequencies are calculated) over the entire
     ! PBL or the first model layer only. For now, set this value
     ! automatically based upon the selected PBL scheme: 1st model layer
     ! for the non-local PBL scheme, full PBL for the full-mixing scheme.
     Input_Opt%PBL_DRYDEP = ( .not. Input_Opt%LNLPBL )
+
+    ! Set whether to reconstruct convective precipitation flux based on
+    ! meteorology source and simulation start date. This is important for
+    ! avoiding a bug where convective precipitation met-fields are all zero
+    ! in GEOS-IT for all years and in GEOS-FP following June 1, 2020.
+    !
+    ! IMPORTANT NOTE: The logic for GEOS-FP assumes (1) meteorology year
+    ! is the same as simulation year and (2) the simulation does not
+    ! run across June 1, 2020. Use the following rules to ensure your
+    ! simulation is correct:
+    !   (1) Manually update code below if GEOS-FP data year is
+    !       different than simulation year:
+    !          - Set to .FALSE. if data is prior to June 1, 2020
+    !          - Set to .TRUE. if data is on or after June 1, 2020
+    !   (2) Do not run a GEOS-FP simulation across June 1, 2020. Split
+    !       up the run in time to avoid this.
+    IF ( Input_Opt%MetField == 'GEOSIT' ) THEN
+       Input_Opt%Reconstruct_Conv_Precip_Flux = .TRUE.
+    ELSEIF ( Input_Opt%MetField == 'GEOSFP' .AND. Input_Opt%NYMDb >= 20200601 ) THEN
+       Input_Opt%Reconstruct_Conv_Precip_Flux = .TRUE.
+    ELSE
+       Input_Opt%Reconstruct_Conv_Precip_Flux = .FALSE.
+    ENDIF
 
     ! Return success
     RC = GC_SUCCESS
@@ -3160,6 +3189,16 @@ CONTAINS
        WRITE( 6, 90  ) 'CONVECTION SETTINGS'
        WRITE( 6, 95  ) '-------------------'
        WRITE( 6, 100 ) 'Turn on cloud convection?   : ', Input_Opt%LCONV
+       WRITE( 6, 100 ) 'Reconstruct convective precipitation flux?   : ', &
+            Input_Opt%Reconstruct_Conv_Precip_Flux
+
+       IF ( Input_Opt%MetFields == 'GEOSFP' ) THEN
+          IF ( Input_Opt%Reconstruct_Conv_Precip_Flux ) THEN
+             WRITE( 6, 90 ) 'WARNING: Convection will assume met data is on or after 01Jun2020!'
+          ELSE
+             WRITE( 6, 90 ) 'WARNING: Convection will assume met data is prior to 01Jun2020!'
+          ENDIF
+       ENDIF
 
        WRITE( 6, 90  ) 'PBL MIXING SETTINGS'
        WRITE( 6, 95  ) '-------------------'

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -229,6 +229,7 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: LCONV
      LOGICAL                     :: LTURB
      LOGICAL                     :: LNLPBL
+     LOGICAL                     :: Reconstruct_Conv_Precip_Flux
      INTEGER                     :: TS_CONV
 
      !----------------------------------------
@@ -739,6 +740,7 @@ CONTAINS
     Input_Opt%LCONV                  = .FALSE.
     Input_Opt%LTURB                  = .FALSE.
     Input_Opt%LNLPBL                 = .FALSE.
+    Input_Opt%Reconstruct_Conv_Precip_Flux = .FALSE.
     Input_Opt%TS_CONV                = 0
 
     !----------------------------------------

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -54,6 +54,9 @@ RUNDIR_VARS+="RUNDIR_GC_MODE='GCClassic'\n"
 thickline="\n===========================================================\n"
 thinline="\n-----------------------------------------------------------\n"
 
+# Define run directory config log
+rundir_config_log=${rundir_config}/rundir_vars.txt
+
 printf "${thickline}GEOS-CHEM RUN DIRECTORY CREATION${thickline}"
 
 #-----------------------------------------------------------------
@@ -353,6 +356,24 @@ while [ "${valid_met}" -eq 0 ]; do
 	met="geosfp"
 	shared_met_settings=${gcdir}/run/shared/settings/geosfp/geosfp.preprocessed_ll.txt
 	RUNDIR_VARS+="RUNDIR_MET_FIELD_CONFIG='HEMCO_Config.rc.gmao_metfields'\n"
+
+	# Print warning about GEOS-FP and require user to acknowledge it.
+	fp_msg="WARNING: The convection scheme used to generate archived GEOS-FP meteorology files changed from RAS to Grell-Freidas starting June 1, 2020 with impact on vertical transport. Discussion and analysis of the impact is available at github.com/geoschem/geos-chem/issues/1409. In addition, there is a bug in convective precipitation flux following the switch where all values are zero. This bug is automatically fixed by computing fluxes online for runs starting on or after June 1 2020, but not for the case of running across the time boundary. Due to these issues we recommend splitting up GEOS-FP runs in time such that a single simulation does not run across June 1, 2020. Instead set one run to stop on June 1 2020 and then restart a new run from there. If you wish to use a GEOS-FP meteorology year different from your simulation year please create a GEOS-Chem GitHub issue for assistance to avoid accidentally using zero convective precipitation flux.\n\nThis warning will be printed to run directory file ${rundir_config_log} for future reference.\n"
+	printf ${fp_msg}
+	valid_fp_accept=0
+	while [ "${valid_fp_accept}" -eq 0 ]; do
+	    read -p "${USER_PROMPT}" fp_accept
+	    valid_fp_accept=1
+	    if [[ ${fp_accept} = "y" ]]; then
+		x=0
+	    elif [[ ${fp_accept} = "q" ]]; then
+		exit
+	    else
+		valid_fp_accept=0
+		printf "Invalid option. Try again.\n"
+	    fi
+	done
+
     elif [[ ${met_num} = "3" ]]; then
 	met="geosit"
 	shared_met_settings=${gcdir}/run/shared/settings/geosit/geosit.preprocessed_ll.txt
@@ -1233,6 +1254,15 @@ if [[ "x${enable_git}" == "xy" ]]; then
 	git commit -m "Update header of rundirConfig/rundir_vars.txt" > /dev/null
 	cd ${srcrundir}
     fi
+fi
+
+
+#-----------------------------------------------------------------
+# If using GEOS-FP then add a warning at top of rundir config log
+#-----------------------------------------------------------------
+if [[ $met == "geosfp" ]]; then
+   cat ${fp_msg} ${rundir_config_log} > tmp.txt
+   mv tmp.txt ${rundir_config_log}
 fi
 
 #-----------------------------------------------------------------

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -54,9 +54,6 @@ RUNDIR_VARS+="RUNDIR_GC_MODE='GCClassic'\n"
 thickline="\n===========================================================\n"
 thinline="\n-----------------------------------------------------------\n"
 
-# Define run directory config log
-rundir_config_log=${rundir_config}/rundir_vars.txt
-
 printf "${thickline}GEOS-CHEM RUN DIRECTORY CREATION${thickline}"
 
 #-----------------------------------------------------------------
@@ -358,8 +355,10 @@ while [ "${valid_met}" -eq 0 ]; do
 	RUNDIR_VARS+="RUNDIR_MET_FIELD_CONFIG='HEMCO_Config.rc.gmao_metfields'\n"
 
 	# Print warning about GEOS-FP and require user to acknowledge it.
-	fp_msg="WARNING: The convection scheme used to generate archived GEOS-FP meteorology files changed from RAS to Grell-Freidas starting June 1, 2020 with impact on vertical transport. Discussion and analysis of the impact is available at github.com/geoschem/geos-chem/issues/1409. In addition, there is a bug in convective precipitation flux following the switch where all values are zero. This bug is automatically fixed by computing fluxes online for runs starting on or after June 1 2020, but not for the case of running across the time boundary. Due to these issues we recommend splitting up GEOS-FP runs in time such that a single simulation does not run across June 1, 2020. Instead set one run to stop on June 1 2020 and then restart a new run from there. If you wish to use a GEOS-FP meteorology year different from your simulation year please create a GEOS-Chem GitHub issue for assistance to avoid accidentally using zero convective precipitation flux.\n\nThis warning will be printed to run directory file ${rundir_config_log} for future reference.\n"
-	printf ${fp_msg}
+	fp_msg="WARNING: The convection scheme used to generate archived GEOS-FP meteorology \nfiles changed from RAS to Grell-Freidas starting June 1 2020 with impact on \nvertical transport. Discussion and analysis of the impact is available at \ngithub.com/geoschem/geos-chem/issues/1409. In addition, there is a bug in \nconvective precipitation flux following the switch where all values are zero \nin the input files. This bug is addressed by computing fluxes online for runs \nstarting on or after June 1 2020. The fix does not extend to the case of running \nacross the time boundary. Due to these issues we recommend splitting up GEOS-FP \nruns in time such that a single simulation does not span the switch. Configure \none run to end on June 1 2020 and then use its output restart to start another \nrun on June 1. Alternatively consider using MERRA2. If you wish to use a \nGEOS-FP meteorology year different from your simulation year please create a \nGEOS-Chem GitHub issue for assistance to avoid accidentally using zero \nconvective precipitation flux.\n"
+	printf "\n${fp_msg}\n"
+	printf "This warning will be printed to run directory file warnings.txt.\n"
+	printf "${thinline}Enter y to acknowledge and proceed, or q to quit:${thinline}"
 	valid_fp_accept=0
 	while [ "${valid_fp_accept}" -eq 0 ]; do
 	    read -p "${USER_PROMPT}" fp_accept
@@ -879,10 +878,6 @@ done
 mkdir -p ${rundir}
 mkdir -p ${rundir}/Restarts
 
-# Define a subdirectory for rundir configuration files
-rundir_config=${rundir}/CreateRunDirLogs
-mkdir -p ${rundir_config}
-
 # Copy run directory files and subdirectories
 cp ${gcdir}/run/shared/cleanRunDir.sh       ${rundir}
 cp ${gcdir}/run/shared/download_data.py     ${rundir}
@@ -1048,8 +1043,13 @@ fi
 # Replace settings in config files with RUNDIR variables
 #--------------------------------------------------------------------
 
+# Define a subdirectory for rundir configuration files
+rundir_config_dirname=CreateRunDirLogs
+mkdir -p ${rundir}/${rundir_config_dirname}
+
 # Save RUNDIR variables to a file in the rundirConfig folder
-rundir_config_log=${rundir_config}/rundir_vars.txt
+rundir_config_logname=rundir_vars.txt
+rundir_config_log=${rundir}/${rundir_config_dirname}/${rundir_config_logname}
 echo -e "$RUNDIR_VARS" > ${rundir_config_log}
 #sort -o ${rundir_config_log} ${rundir_config_log}
 
@@ -1058,10 +1058,10 @@ echo -e "$RUNDIR_VARS" > ${rundir_config_log}
 ${srcrundir}/init_rd.sh ${rundir_config_log}
 
 #--------------------------------------------------------------------
-# Print run direcory setup info to screen
+# Print run directory setup info to screen
 #--------------------------------------------------------------------
 
-printf "\n  -- See rundir_vars.txt for summary of default run directory settings"
+printf "\n  -- See ${rundir_config_dirname}/${rundir_config_logname} for summary of default run directory settings"
 printf "\n  -- This run directory has been set up to start on ${startdate}"
 printf "\n  -- A restart file for this date has been copied to the Restarts subdirectory"
 printf "\n  -- You may add more restart files using format GEOSChem.Restart.YYYYMMDD_HHmmz.nc4"
@@ -1154,7 +1154,7 @@ commit_hash=$(git log -n 1 --pretty=format:"%h")
 cd ${srcrundir}
 
 # Write commit info to a version log
-version_log=${rundir_config}/rundir.version
+version_log=${rundir}/${rundir_config_dirname}/rundir.version
 printf   " This run directory was created with:"        >  ${version_log}
 printf "\n ${srcrundir}/createRunDir.sh.\n"             >> ${version_log}
 printf "\n GEOS-Chem repository version information:\n" >> ${version_log}
@@ -1235,7 +1235,7 @@ unset msg
 printf "\n\n IMPORTANT: ONLY USE THESE RUNDIR SETTINGS WITH THIS COMMIT!\n" >> ${version_log}
 
 # Add a "# " characters to the front of each line so we can use
-# it as a comment heading for rundir_vars.txt
+# it as a comment heading for ${rundir_config_logname}
 sed 's/^/# /' ${version_log} > tmp.txt
 mv tmp.txt ${version_log}
 
@@ -1251,18 +1251,16 @@ if [[ "x${enable_git}" == "xy" ]]; then
     if [[ -f ${rundir_config_log} ]]; then
 	cd ${rundir}
 	git add ${rundir_config_log}
-	git commit -m "Update header of rundirConfig/rundir_vars.txt" > /dev/null
+	git commit -m "Update header of ${rundir_config_dirname}/${rundir_config_logname}" > /dev/null
 	cd ${srcrundir}
     fi
 fi
 
-
 #-----------------------------------------------------------------
-# If using GEOS-FP then add a warning at top of rundir config log
+# Create and populate warnings file
 #-----------------------------------------------------------------
 if [[ $met == "geosfp" ]]; then
-   cat ${fp_msg} ${rundir_config_log} > tmp.txt
-   mv tmp.txt ${rundir_config_log}
+   echo -e ${fp_msg} > ${rundir}/warnings.txt
 fi
 
 #-----------------------------------------------------------------

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -52,9 +52,6 @@ RUNDIR_VARS+="RUNDIR_GC_MODE='GCHP'\n"
 thickline="\n===========================================================\n"
 thinline="\n-----------------------------------------------------------\n"
 
-# Define run directory config log
-rundir_config_log=${rundir_config}/rundir_vars.txt
-
 printf "${thickline}GCHP RUN DIRECTORY CREATION${thickline}"
 
 #-----------------------------------------------------------------
@@ -321,8 +318,10 @@ while [ "${valid_met}" -eq 0 ]; do
        	met="geosfp"
 
 	# Print warning about GEOS-FP and require user to acknowledge it.
-	fp_msg="WARNING: The convection scheme used to generate archived GEOS-FP meteorology files changed from RAS to Grell-Freidas starting June 1, 2020 with impact on vertical transport. Discussion and analysis of the impact is available at github.com/geoschem/geos-chem/issues/1409. In addition, there is a bug in convective precipitation flux following the switch where all values are zero. This bug is automatically fixed by computing fluxes online for runs starting on or after June 1 2020, but not for the case of running across the time boundary. Due to these issues we recommend splitting up GEOS-FP runs in time such that a single simulation does not run across June 1, 2020. Instead set one run to stop on June 1 2020 and then restart a new run from there. If you wish to use a GEOS-FP meteorology year different from your simulation year please create a GEOS-Chem GitHub issue for assistance to avoid accidentally using zero convective precipitation flux.\n\nThis warning will be printed to run directory file ${rundir_config_log} for future reference.\n"
-	printf ${fp_msg}
+	fp_msg="WARNING: The convection scheme used to generate archived GEOS-FP meteorology \nfiles changed from RAS to Grell-Freidas starting June 1 2020 with impact on \nvertical transport. Discussion and analysis of the impact is available at \ngithub.com/geoschem/geos-chem/issues/1409. In addition, there is a bug in \nconvective precipitation flux following the switch where all values are zero \nin the input files. This bug is addressed by computing fluxes online for runs \nstarting on or after June 1 2020. The fix does not extend to the case of running \nacross the time boundary. Due to these issues we recommend splitting up GEOS-FP \nruns in time such that a single simulation does not span the switch. Configure \none run to end on June 1 2020 and then use its output restart to start another \nrun on June 1. Alternatively consider using MERRA2. If you wish to use a \nGEOS-FP meteorology year different from your simulation year please create a \nGEOS-Chem GitHub issue for assistance to avoid accidentally using zero \nconvective precipitation flux.\n"
+	printf "\n${fp_msg}\n"
+	printf "This warning will be printed to run directory file warnings.txt.\n"
+	printf "${thinline}Enter y to acknowledge and proceed, or q to quit:${thinline}"
 	valid_fp_accept=0
 	while [ "${valid_fp_accept}" -eq 0 ]; do
 	    read -p "${USER_PROMPT}" fp_accept
@@ -336,7 +335,7 @@ while [ "${valid_met}" -eq 0 ]; do
 		printf "Invalid option. Try again.\n"
 	    fi
 	done
-	
+
         # Ask user to specify processed or raw files
         printf "${thinline}Choose meteorology file type:${thinline}"
 	printf "  1. 0.25x0.3125 daily files pre-processed for GEOS-Chem\n"
@@ -620,10 +619,6 @@ done
 mkdir -p ${rundir}
 mkdir -p ${rundir}/Restarts
 
-# Define a subdirectory for rundir configuration files
-rundir_config=${rundir}/CreateRunDirLogs
-mkdir -p ${rundir_config}
-
 # Copy run directory files and subdirectories
 cp ${gcdir}/run/shared/cleanRunDir.sh ${rundir}
 cp ./archiveRun.sh                    ${rundir}
@@ -798,7 +793,14 @@ fi
 # Replace settings in config files with RUNDIR variables
 #--------------------------------------------------------------------
 
-# Save RUNDIR variables to file
+# Define a subdirectory for rundir configuration files
+rundir_config_dirname=CreateRunDirLogs
+rundir_config=${rundir}/${rundir_config_dirname}
+mkdir -p ${rundir_config}
+
+# Save RUNDIR variables to a file in the rundirConfig folder
+rundir_config_logname=rundir_vars.txt
+rundir_config_log=${rundir}/${rundir_config_dirname}/${rundir_config_logname}
 echo -e "$RUNDIR_VARS" > ${rundir_config_log}
 
 # Initialize run directory
@@ -831,7 +833,7 @@ cd ${srcrundir}
 #----------------------------------------------------------------------
 # Archive repository version in run directory file rundir.version
 #----------------------------------------------------------------------
-version_log=${rundir_config}/rundir.version
+version_log=${rundir}/${rundir_config_dirname}/rundir.version
 echo "This run directory was created with ${srcrundir}/createRunDir.sh." > ${version_log}
 echo " " >> ${version_log}
 echo "GEOS-Chem repository version information:" >> ${version_log}
@@ -877,19 +879,8 @@ while [ "$valid_response" -eq 0 ]; do
     fi
 done
 
-#-----------------------------------------------------------------
-# If using GEOS-FP then add a warning at top of rundir config log
-#-----------------------------------------------------------------
-if [[ $met == "geosfp" ]]; then
-   cat ${fp_msg} ${rundir_config_log} > tmp.txt
-   mv tmp.txt ${rundir_config_log}
-fi
-
-#-----------------------------------------------------------------
-# Done!
-#-----------------------------------------------------------------
-
 printf "\n${thinline}Created ${rundir}\n"
+printf "\n  -- See ${rundir_config_dirname}/${rundir_config_logname} for summary of default run directory settings"
 printf "\n  -- This run directory is set up for simulation start date $start_date"
 printf "\n  -- Restart files for this date at different grid resolutions are in the"
 printf "\n     Restarts subdirectory"
@@ -935,5 +926,46 @@ msg+="$ make -j\n"
 msg+="$ make install\n"
 printf "${msg}" > ${rundir}/build/README
 unset msg
+
+#-----------------------------------------------------------------
+# Add the version info to the top of the rundir configuration log
+#-----------------------------------------------------------------
+
+# Add a caveat that these rundir settings only go with this commit
+printf "\n\n IMPORTANT: ONLY USE THESE RUNDIR SETTINGS WITH THIS COMMIT!\n" >> ${version_log}
+
+# Add a "# " characters to the front of each line so we can use
+# it as a comment heading for ${rundir_config_logname}
+sed 's/^/# /' ${version_log} > tmp.txt
+mv tmp.txt ${version_log}
+
+# Add the version log to the top of the rundir config log
+cat ${version_log} ${rundir_config_log} > tmp.txt
+mv tmp.txt ${rundir_config_log}
+
+# Remove the version log
+rm -rf ${version_log}
+
+# Save the updated rundir_vars file to the git repo
+if [[ "x${enable_git}" == "xy" ]]; then
+    if [[ -f ${rundir_config_log} ]]; then
+	cd ${rundir}
+	git add ${rundir_config_log}
+	git commit -m "Update header of ${rundir_config_dirname}/${rundir_config_lognbame}" > /dev/null
+	cd ${srcrundir}
+    fi
+fi
+
+#-----------------------------------------------------------------
+# Create and populate warnings file
+#-----------------------------------------------------------------
+if [[ $met == "geosfp" ]]; then
+   echo -e ${fp_msg} > ${rundir}/warnings.txt
+fi
+
+#-----------------------------------------------------------------
+# Done!
+#-----------------------------------------------------------------
+printf "\nCreated ${rundir}\n"
 
 exit 0

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -52,6 +52,9 @@ RUNDIR_VARS+="RUNDIR_GC_MODE='GCHP'\n"
 thickline="\n===========================================================\n"
 thinline="\n-----------------------------------------------------------\n"
 
+# Define run directory config log
+rundir_config_log=${rundir_config}/rundir_vars.txt
+
 printf "${thickline}GCHP RUN DIRECTORY CREATION${thickline}"
 
 #-----------------------------------------------------------------
@@ -317,6 +320,23 @@ while [ "${valid_met}" -eq 0 ]; do
 
        	met="geosfp"
 
+	# Print warning about GEOS-FP and require user to acknowledge it.
+	fp_msg="WARNING: The convection scheme used to generate archived GEOS-FP meteorology files changed from RAS to Grell-Freidas starting June 1, 2020 with impact on vertical transport. Discussion and analysis of the impact is available at github.com/geoschem/geos-chem/issues/1409. In addition, there is a bug in convective precipitation flux following the switch where all values are zero. This bug is automatically fixed by computing fluxes online for runs starting on or after June 1 2020, but not for the case of running across the time boundary. Due to these issues we recommend splitting up GEOS-FP runs in time such that a single simulation does not run across June 1, 2020. Instead set one run to stop on June 1 2020 and then restart a new run from there. If you wish to use a GEOS-FP meteorology year different from your simulation year please create a GEOS-Chem GitHub issue for assistance to avoid accidentally using zero convective precipitation flux.\n\nThis warning will be printed to run directory file ${rundir_config_log} for future reference.\n"
+	printf ${fp_msg}
+	valid_fp_accept=0
+	while [ "${valid_fp_accept}" -eq 0 ]; do
+	    read -p "${USER_PROMPT}" fp_accept
+	    valid_fp_accept=1
+	    if [[ ${fp_accept} = "y" ]]; then
+		x=0
+	    elif [[ ${fp_accept} = "q" ]]; then
+		exit
+	    else
+		valid_fp_accept=0
+		printf "Invalid option. Try again.\n"
+	    fi
+	done
+	
         # Ask user to specify processed or raw files
         printf "${thinline}Choose meteorology file type:${thinline}"
 	printf "  1. 0.25x0.3125 daily files pre-processed for GEOS-Chem\n"
@@ -779,7 +799,6 @@ fi
 #--------------------------------------------------------------------
 
 # Save RUNDIR variables to file
-rundir_config_log=${rundir_config}/rundir_vars.txt
 echo -e "$RUNDIR_VARS" > ${rundir_config_log}
 
 # Initialize run directory
@@ -857,6 +876,14 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "Input not recognized. Try again.\n"
     fi
 done
+
+#-----------------------------------------------------------------
+# If using GEOS-FP then add a warning at top of rundir config log
+#-----------------------------------------------------------------
+if [[ $met == "geosfp" ]]; then
+   cat ${fp_msg} ${rundir_config_log} > tmp.txt
+   mv tmp.txt ${rundir_config_log}
+fi
 
 #-----------------------------------------------------------------
 # Done!

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.CO2
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.CO2
@@ -10,6 +10,7 @@
 #============================================================================
 simulation:
   name: ${RUNDIR_SIM_NAME}
+  met_field: ${RUNDIR_MET}
   chem_inputs_dir: ./ChemDir/
   species_database_file: ./species_database.yml
   species_metadata_output_file: OutputDir/geoschem_species_metadata.yml

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
@@ -10,6 +10,7 @@
 #============================================================================
 simulation:
   name: ${RUNDIR_SIM_NAME}
+  met_field: ${RUNDIR_MET}
   chem_inputs_dir: ./ChemDir/
   species_database_file: ./species_database.yml
   species_metadata_output_file: OutputDir/geoschem_species_metadata.yml

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -7,6 +7,7 @@
 #============================================================================
 simulation:
   name: ${RUNDIR_SIM_NAME}
+  met_field: ${RUNDIR_MET}
   chem_inputs_dir: ./ChemDir/
   species_database_file: ./species_database.yml
   species_metadata_output_file: OutputDir/geoschem_species_metadata.yml

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -10,6 +10,7 @@
 #============================================================================
 simulation:
   name: ${RUNDIR_SIM_NAME}
+  met_field: ${RUNDIR_MET}
   chem_inputs_dir: ./ChemDir/
   species_database_file: ./species_database.yml
   species_metadata_output_file: OutputDir/geoschem_species_metadata.yml

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.tagO3
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.tagO3
@@ -10,6 +10,7 @@
 #============================================================================
 simulation:
   name: ${RUNDIR_SIM_NAME}
+  met_field: ${RUNDIR_MET}
   chem_inputs_dir: ./ChemDir/
   species_database_file: ./species_database.yml
   species_metadata_output_file: OutputDir/geoschem_species_metadata.yml


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

1. Added meteorology source name to GCHP run directory `geoschem_config.yml`
2. Created new `Input_Opt` logical for whether to reconstruct convective precipitation flux. This switch is set automatically during run-time to true for GEOS-IT, true for GEOS-FP if start date is June 1 2020 or later, and false for all other cases.
4. Used the new `Input_Opt` logical to tap into the code @yuanjianz implemented in this branch already.
5. Added a warning during run directory creation about the convection scheme change and the precipitation flux bug (only if selecting GEOS-FP meteorology). This warning stops run directory creation and requires acknowledgement from the user to continue.
6. Updated change log for updates by both me and @yuanjianz.

### Expected changes

I will update the main PR description after merge to reflect that me and Viral as contributors and further describe the updates.

### Related Github Issue

These changes are the implementation agreed upon in https://github.com/geoschem/geos-chem/issues/2469.
